### PR TITLE
Add explicit casts to ufunc loop functions.

### DIFF
--- a/python/ora/ext/np.hh
+++ b/python/ora/ext/np.hh
@@ -354,7 +354,7 @@ create_or_get_ufunc(
 /*
  * Wraps a unary function `FN(ARG0) -> RET0` in a ufunc loop function
  */
-template<class ARG0, class RET0, RET0 (*FN)(ARG0)>
+template<class ARG0, class RET0, RET0 (*FN)(ARG0 const) noexcept>
 void
 ufunc_loop_1(
   char** const args,
@@ -422,22 +422,22 @@ public:
 
     create_or_get_ufunc(np_module, "equal", 2, 1)->add_loop_2(
       type_num, type_num, NPY_BOOL,
-      ufunc_loop_2<TYPE, TYPE, npy_bool, equal>);
+      (PyUFuncGenericFunction) ufunc_loop_2<TYPE, TYPE, npy_bool, equal>);
     create_or_get_ufunc(np_module, "not_equal", 2, 1)->add_loop_2(
       type_num, type_num, NPY_BOOL,
-      ufunc_loop_2<TYPE, TYPE, npy_bool, not_equal>);
+      (PyUFuncGenericFunction) ufunc_loop_2<TYPE, TYPE, npy_bool, not_equal>);
     create_or_get_ufunc(np_module, "less", 2, 1)->add_loop_2(
       type_num, type_num, NPY_BOOL,
-      ufunc_loop_2<TYPE, TYPE, npy_bool, less>);
+      (PyUFuncGenericFunction) ufunc_loop_2<TYPE, TYPE, npy_bool, less>);
     create_or_get_ufunc(np_module, "less_equal", 2, 1)->add_loop_2(
       type_num, type_num, NPY_BOOL,
-      ufunc_loop_2<TYPE, TYPE, npy_bool, less_equal>);
+      (PyUFuncGenericFunction) ufunc_loop_2<TYPE, TYPE, npy_bool, less_equal>);
     create_or_get_ufunc(np_module, "greater", 2, 1)->add_loop_2(
       type_num, type_num, NPY_BOOL,
-      ufunc_loop_2<TYPE, TYPE, npy_bool, greater>);
+      (PyUFuncGenericFunction) ufunc_loop_2<TYPE, TYPE, npy_bool, greater>);
     create_or_get_ufunc(np_module, "greater_equal", 2, 1)->add_loop_2(
       type_num, type_num, NPY_BOOL,
-      ufunc_loop_2<TYPE, TYPE, npy_bool, greater_equal>);
+      (PyUFuncGenericFunction) ufunc_loop_2<TYPE, TYPE, npy_bool, greater_equal>);
   }
 
 private:

--- a/python/ora/ext/np_date.hh
+++ b/python/ora/ext/np_date.hh
@@ -258,31 +258,31 @@ DateDtype<PYDATE>::add(
     module, "get_day", 1, 1, docstring::np_date::get_day
     )->add_loop_1(
       dtype->type_num, NPY_UINT8, 
-      ufunc_loop_1<Date, npy_bool, ora::date::nex::get_day<Date>>);
+      (PyUFuncGenericFunction) ufunc_loop_1<Date, Day, ora::date::nex::get_day<Date>>);
   create_or_get_ufunc(module, "get_month", 1, 1)->add_loop_1(
     dtype->type_num, NPY_UINT8, 
-    ufunc_loop_1<Date, npy_bool, ora::date::nex::get_month<Date>>);
+    (PyUFuncGenericFunction) ufunc_loop_1<Date, Month, ora::date::nex::get_month<Date>>);
   create_or_get_ufunc(module, "get_ordinal_date", 1, 1)->add_loop_1(
     dtype, get_ordinal_date_dtype(),
-    ufunc_loop_1<Date, ora::OrdinalDate, ora::date::nex::get_ordinal_date<Date>>);
+    (PyUFuncGenericFunction) ufunc_loop_1<Date, ora::OrdinalDate, ora::date::nex::get_ordinal_date<Date>>);
   create_or_get_ufunc(module, "get_week_date", 1, 1)->add_loop_1(
     dtype, get_week_date_dtype(),
-    ufunc_loop_1<Date, ora::WeekDate, ora::date::nex::get_week_date<Date>>);
+    (PyUFuncGenericFunction) ufunc_loop_1<Date, ora::WeekDate, ora::date::nex::get_week_date<Date>>);
   create_or_get_ufunc(module, "get_weekday", 1, 1)->add_loop_1(
     dtype->type_num, NPY_UINT8,
-    ufunc_loop_1<Date, npy_bool, ora::date::nex::get_weekday<Date>>);
+    (PyUFuncGenericFunction) ufunc_loop_1<Date, npy_bool, ora::date::nex::get_weekday<Date>>);
   create_or_get_ufunc(module, "get_year", 1, 1)->add_loop_1(
     dtype->type_num, NPY_INT16, 
-    ufunc_loop_1<Date, int16_t, ora::date::nex::get_year<Date>>);
+    (PyUFuncGenericFunction) ufunc_loop_1<Date, int16_t, ora::date::nex::get_year<Date>>);
   create_or_get_ufunc(module, "get_ymd", 1, 1)->add_loop_1(
     dtype, get_ymd_dtype(),
-    ufunc_loop_1<Date, ora::YmdDate, ora::date::nex::get_ymd<Date>>);
+    (PyUFuncGenericFunction) ufunc_loop_1<Date, ora::YmdDate, ora::date::nex::get_ymd<Date>>);
   create_or_get_ufunc(module, "get_ymdi", 1, 1)->add_loop_1(
     dtype->type_num, NPY_INT32, 
-    ufunc_loop_1<Date, int32_t, ora::date::nex::get_ymdi<Date>>);
+    (PyUFuncGenericFunction) ufunc_loop_1<Date, int32_t, ora::date::nex::get_ymdi<Date>>);
   create_or_get_ufunc(module, "is_valid", 1, 1)->add_loop_1(
     dtype->type_num, NPY_BOOL,
-    ufunc_loop_1<Date, npy_bool, is_valid>);
+    (PyUFuncGenericFunction) ufunc_loop_1<Date, npy_bool, is_valid>);
 
   Comparisons<Date, ora::date::nex::equal, ora::date::nex::before>
     ::register_loops(dtype->type_num);
@@ -290,22 +290,22 @@ DateDtype<PYDATE>::add(
   // Add ufunc loops.
   create_or_get_ufunc(np_module, "add", 2, 1)->add_loop_2(
     dtype->type_num, NPY_INT64, dtype->type_num,
-    ufunc_loop_2<Date, int64_t, Date, add>);
+    (PyUFuncGenericFunction) ufunc_loop_2<Date, int64_t, Date, add>);
   create_or_get_ufunc(np_module, "subtract", 2, 1)->add_loop_2(
     dtype->type_num, NPY_INT64, dtype->type_num,
-    ufunc_loop_2<Date, int64_t, Date, subtract_before>);
+    (PyUFuncGenericFunction) ufunc_loop_2<Date, int64_t, Date, subtract_before>);
   create_or_get_ufunc(np_module, "subtract", 2, 1)->add_loop_2(
     dtype->type_num, dtype->type_num, NPY_INT32,
-    ufunc_loop_2<Date, Date, int32_t, subtract_between>);
+    (PyUFuncGenericFunction) ufunc_loop_2<Date, Date, int32_t, subtract_between>);
 
   static_assert(IntType<Offset>::type_num >= 0, "no type num for offset type");
   create_or_get_ufunc(module, "to_offset", 1, 1)->add_loop_1(
     dtype->type_num, IntType<Offset>::type_num,
-    ufunc_loop_1<Date, Offset, ora::date::nex::get_offset<Date>>);
+    (PyUFuncGenericFunction) ufunc_loop_1<Date, Offset, ora::date::nex::get_offset<Date>>);
 
   create_or_get_ufunc(module, "is_valid", 1, 1)->add_loop_1(
     dtype->type_num, NPY_BOOL,
-    ufunc_loop_1<Date, bool, ora::date::nex::is_valid>);
+    (PyUFuncGenericFunction) ufunc_loop_1<Date, bool, ora::date::nex::is_valid>);
 }
 
 

--- a/python/ora/ext/np_daytime.hh
+++ b/python/ora/ext/np_daytime.hh
@@ -217,38 +217,38 @@ DaytimeDtype<PYDAYTIME>::add(
   // Add ufunc loops.
   create_or_get_ufunc(module, "get_hour", 1, 1)->add_loop_1(
     dtype->type_num, NPY_UINT8,
-    ufunc_loop_1<Daytime, uint8_t, ora::daytime::nex::get_hour>);
+    (PyUFuncGenericFunction) ufunc_loop_1<Daytime, uint8_t, ora::daytime::nex::get_hour>);
   create_or_get_ufunc(module, "get_minute", 1, 1)->add_loop_1(
     dtype->type_num, NPY_UINT8,
-    ufunc_loop_1<Daytime, uint8_t, ora::daytime::nex::get_minute>);
+    (PyUFuncGenericFunction) ufunc_loop_1<Daytime, uint8_t, ora::daytime::nex::get_minute>);
   create_or_get_ufunc(module, "get_second", 1, 1)->add_loop_1(
     dtype->type_num, NPY_FLOAT64,
-    ufunc_loop_1<Daytime, double, ora::daytime::nex::get_second>);
+    (PyUFuncGenericFunction) ufunc_loop_1<Daytime, double, ora::daytime::nex::get_second>);
   create_or_get_ufunc(module, "get_ssm", 1, 1)->add_loop_1(
     dtype->type_num, NPY_FLOAT64,
-    ufunc_loop_1<Daytime, double, ora::daytime::nex::get_ssm>);
+    (PyUFuncGenericFunction) ufunc_loop_1<Daytime, double, ora::daytime::nex::get_ssm>);
   create_or_get_ufunc(module, "get_hms", 1, 1)->add_loop_1(
     dtype, get_hms_dtype(),
-    ufunc_loop_1<Daytime, ora::HmsDaytimePacked, ora::daytime::nex::get_hms_packed<Daytime>>);
+    (PyUFuncGenericFunction) ufunc_loop_1<Daytime, ora::HmsDaytimePacked, ora::daytime::nex::get_hms_packed<Daytime>>);
 
   create_or_get_ufunc(np_module, "add", 2, 1)->add_loop_2(
     dtype->type_num, NPY_FLOAT64, dtype->type_num,
-    ufunc_loop_2<Daytime, double, Daytime, add>);
+    (PyUFuncGenericFunction) ufunc_loop_2<Daytime, double, Daytime, add>);
   create_or_get_ufunc(np_module, "subtract", 2, 1)->add_loop_2(
     dtype->type_num, NPY_FLOAT64, dtype->type_num,
-    ufunc_loop_2<Daytime, double, Daytime, subtract_before>);
+    (PyUFuncGenericFunction) ufunc_loop_2<Daytime, double, Daytime, subtract_before>);
   create_or_get_ufunc(np_module, "subtract", 2, 1)->add_loop_2(
     dtype->type_num, dtype->type_num, NPY_FLOAT64,
-    ufunc_loop_2<Daytime, Daytime, double, subtract_between>);
+    (PyUFuncGenericFunction) ufunc_loop_2<Daytime, Daytime, double, subtract_between>);
 
   static_assert(IntType<Offset>::type_num >= 0, "no type num for offset type");
   create_or_get_ufunc(module, "to_offset", 1, 1)->add_loop_1(
     dtype->type_num, IntType<Offset>::type_num,
-    ufunc_loop_1<Daytime, Offset, ora::daytime::nex::get_offset<Daytime>>);
+    (PyUFuncGenericFunction) ufunc_loop_1<Daytime, Offset, ora::daytime::nex::get_offset<Daytime>>);
 
   create_or_get_ufunc(module, "is_valid", 1, 1)->add_loop_1(
     dtype->type_num, NPY_BOOL,
-    ufunc_loop_1<Daytime, bool, ora::daytime::nex::is_valid>);
+    (PyUFuncGenericFunction) ufunc_loop_1<Daytime, bool, ora::daytime::nex::is_valid>);
 }
 
 

--- a/python/ora/ext/np_time.hh
+++ b/python/ora/ext/np_time.hh
@@ -254,29 +254,29 @@ TimeDtype<PYTIME>::set_up(
   // Arithmetic by seconds.
   create_or_get_ufunc(np_module, "add", 2, 1)->add_loop_2(
     type_num, NPY_FLOAT64, type_num,
-    ufunc_loop_2<Time, float64_t, Time, add>);
+    (PyUFuncGenericFunction) ufunc_loop_2<Time, float64_t, Time, add>);
   create_or_get_ufunc(np_module, "add", 2, 1)->add_loop_2(
     NPY_FLOAT64, type_num, type_num,
-    ufunc_loop_2<float64_t, Time, Time, add>);
+    (PyUFuncGenericFunction) ufunc_loop_2<float64_t, Time, Time, add>);
   create_or_get_ufunc(np_module, "add", 2, 1)->add_loop_2(
     type_num, NPY_INT64, type_num,
-    ufunc_loop_2<Time, int64_t, Time, add>);
+    (PyUFuncGenericFunction) ufunc_loop_2<Time, int64_t, Time, add>);
   create_or_get_ufunc(np_module, "subtract", 2, 1)->add_loop_2(
     type_num, NPY_FLOAT64, type_num,
-    ufunc_loop_2<Time, float64_t, Time, subtract>);
+    (PyUFuncGenericFunction) ufunc_loop_2<Time, float64_t, Time, subtract>);
   create_or_get_ufunc(np_module, "subtract", 2, 1)->add_loop_2(
     type_num, type_num, NPY_FLOAT64, 
-    ufunc_loop_2<Time, Time, float64_t, subtract>);
+    (PyUFuncGenericFunction) ufunc_loop_2<Time, Time, float64_t, subtract>);
 
   // Conversion to offset; not available for 128-bit integer types.
   if (offset_type_num != -1)
     create_or_get_ufunc(module, "to_offset", 1, 1)->add_loop_1(
       type_num, offset_type_num,
-      ufunc_loop_1<Time, Offset, ora::time::nex::get_offset<Time>>);
+      (PyUFuncGenericFunction) ufunc_loop_1<Time, Offset, ora::time::nex::get_offset<Time>>);
 
   create_or_get_ufunc(module, "is_valid", 1, 1)->add_loop_1(
       type_num, NPY_BOOL,
-      ufunc_loop_1<Time, bool, ora::time::nex::is_valid>);
+      (PyUFuncGenericFunction) ufunc_loop_1<Time, bool, ora::time::nex::is_valid>);
 }
 
 

--- a/setup.py
+++ b/setup.py
@@ -67,7 +67,7 @@ setup(
         "License :: OSI Approved :: BSD License",
         "Programming Language :: Python :: 3",
         "Programming Language :: Python :: 3.6",
-    ],    
+    ],
 
     python_requires='>=3.6',
     install_requires=[
@@ -85,8 +85,9 @@ setup(
         Extension(
             "ora.ext",
             extra_compile_args=[
-                "-std=c++14", 
-                "-fdiagnostics-color=always", 
+                "-std=c++14",
+                "-fdiagnostics-color=always",
+                "-Wno-dangling-else",
             ],
             include_dirs      =[
                 "cxx/include",
@@ -94,8 +95,8 @@ setup(
                 *get_numpy_include_dirs(),
             ],
             sources           =glob("python/ora/ext/*.cc"),
-            library_dirs      =["cxx/src",],
-            libraries         =["ora",],
+            library_dirs      =["cxx/src", ],
+            libraries         =["ora", ],
             depends           =[
                 *glob("cxx/include/*.hh"),
                 *glob("python/ora/ext/*.hh"),


### PR DESCRIPTION
This seems to be necessary for GCC 9 in c++14 mode.  I'm not sure entirely why.