### PR TITLE
use zoneinfo from system or tzdata

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,7 @@
+# v0.8
+
+- Ora now chooses a zoneinfo directory similarly to the standard `zoneinfo`
+  module.  By default, it uses a system zoneinfo directory, if available; 
+  else, the data installed with the `tzdata` module, if available; else the
+  zoneinfo directory packaged with Ora itself.
+

--- a/docs/time-zones.rst
+++ b/docs/time-zones.rst
@@ -8,10 +8,6 @@ Time Zones
 <https://data.iana.org/time-zones/theory.html>`_ for information about the tz
 database and its limitations.
 
-Ora includes and uses a recent copy of the zoneinfo files, distinct from those
-typically installed on UNIX-like systems or those installed with `dateutil` or
-`pytz`.
-
 
 Time zone objects
 -----------------
@@ -94,4 +90,34 @@ time zone*) instead, use `at_local()`.
 
     >>> tz.at_local(2016/Mar/18, MIDNIGHT)
     TimeZoneParts(offset=-14400, abbreviation='EDT', is_dst=True)
+
+
+Time zone data
+--------------
+
+Ora uses a method similar to the standard library's `zoneinfo` module to choose
+an available zoneinfo database, according to these rules:
+
+1. The first entry of `zoneinfo.TZPATH
+   <https://docs.python.org/3/library/zoneinfo.html#zoneinfo.TZPATH>`_ that is
+   an absolute path to a directory, if any.  By default, `TZPATH` is initialized
+   from the `PYTHONTZPATH` environment variable, if set.  Otherwise, it is
+   initialized to a Python distribution-specific list of typical paths at which
+   system zoneinfo directories are typically located.  On UNIX-like systems,
+   this is most commonly `/usr/share/zoneinfo`.
+
+2. Or, the zoneinfo directory installed with the PyPI `tzdata
+   <https://tzdata.readthedocs.io/en/latest/>`_ package, if `tzdata` is
+   installed.
+
+3. Or, a copy of the zoneinfo database packaged with Ora itself.
+
+In most Python installations, Ora uses the system-installed zoneinfo by default.
+To avoid using the system zoneinfo, set `PYTHONTZPATH` to an empty string.  Ora
+will use zoneinfo from the `tzdata` package, if installed, else its own copy.
+
+To instruct Ora to use a specific zoneinfo directory, set the `PYTHONTZPATH`
+environment variable to the absolute path, or call `set_zoneinfo_dir()`.  Ora
+caches loaded time zone objects; any already loaded will not be reloaded if the
+zoneinfo directory is changed by `set_zoneinfo_dir()`.
 

--- a/docs/time-zones.rst
+++ b/docs/time-zones.rst
@@ -117,7 +117,12 @@ To avoid using the system zoneinfo, set `PYTHONTZPATH` to an empty string.  Ora
 will use zoneinfo from the `tzdata` package, if installed, else its own copy.
 
 To instruct Ora to use a specific zoneinfo directory, set the `PYTHONTZPATH`
-environment variable to the absolute path, or call `set_zoneinfo_dir()`.  Ora
-caches loaded time zone objects; any already loaded will not be reloaded if the
-zoneinfo directory is changed by `set_zoneinfo_dir()`.
+environment variable to the absolute path, or call `set_zoneinfo_dir(path)`.
+Ora caches loaded time zone objects; any already loaded will not be reloaded if
+the zoneinfo directory is changed by `set_zoneinfo_dir()`.
+
+Use `get_zoneinfo_dir()` to determine the zoneinfo version of the current
+zoneinfo directory, or another directory by passing a path.  Note that there is
+no standard for storing the version of a zoneinfo directory; Ora makes an effort
+to infer this from conventional metadata, but this is not always possible.
 

--- a/python/ora/__init__.py
+++ b/python/ora/__init__.py
@@ -114,7 +114,7 @@ DAYTIME_TYPES = frozenset((
 ))
 
 
-_INTERNAL_ZONEINFO_DIR = Path(__file__).parent / "tzdata"
+_INTERNAL_ZONEINFO_DIR = Path(__file__).parent / "zoneinfo"
 
 def _get_default_zoneinfo_dir() -> Path:
     """

--- a/python/ora/ext/functions.cc
+++ b/python/ora/ext/functions.cc
@@ -457,10 +457,10 @@ set_zoneinfo_dir(
   Dict* const kw_args)
 {
   static char const* arg_names[] = {"path", nullptr};
-  char* path;
-  Arg::ParseTupleAndKeywords(args, kw_args, "s", arg_names, &path);
+  Object* path_obj;
+  Arg::ParseTupleAndKeywords(args, kw_args, "O", arg_names, &path_obj);
 
-  ora::set_zoneinfo_dir(path);
+  ora::set_zoneinfo_dir(fspath(path_obj));
   return none_ref();
 }
 

--- a/python/ora/ext/py.hh
+++ b/python/ora/ext/py.hh
@@ -990,6 +990,21 @@ public:
 
 //------------------------------------------------------------------------------
 
+class Bytes
+  : public Object
+{
+public:
+
+  static bool Check(PyObject* obj)
+    { return PyBytes_Check(obj); }
+
+  char* as_string()
+    { return PyBytes_AS_STRING(this); }
+
+};
+
+//------------------------------------------------------------------------------
+
 class Unicode
   : public Object
 {
@@ -2010,6 +2025,20 @@ new_exception(
   check_not_null(exc);
   assert(Type::Check(exc));
   return ref<Object>::take(exc);
+}
+
+
+inline char const*
+fspath(
+  PyObject* obj)
+{
+  ref<Object> path = take_not_null<Object>(PyOS_FSPath(obj));
+  if (Unicode::Check(path))
+    return cast<Unicode>(path)->as_utf8();
+  else if (Bytes::Check(path))
+    return cast<Bytes>(path)->as_string();
+  else
+    throw TypeError("unknown path type");
 }
 
 

--- a/python/ora/test/test_time_zone_dir.py
+++ b/python/ora/test/test_time_zone_dir.py
@@ -1,0 +1,64 @@
+import os
+from   pathlib import Path
+import pytest
+import subprocess
+import sys
+
+try:
+    import tzdata
+except ImportError:
+    tzdata = None
+
+# Note: if PYTHONTZPATH is the empty string, `zoneinfo.TZPATH` contains a single
+# entry, `.`.  However, `zoneinfo` ignores relative dir paths in `TZPATH`.
+
+#-------------------------------------------------------------------------------
+
+def run(script, zoneinfo_path):
+    """
+    Runs `script` in a Python subprocess with env var PYTHONTZPATH set to
+    `zoneinfo_path` or none.
+    """
+    env_var = "PYTHONTZPATH"
+
+    env = os.environ.copy()
+    if zoneinfo_path is None:
+        env.pop(env_var, None)
+    else:
+        env[env_var] = str(zoneinfo_path)
+
+    proc = subprocess.run(
+        [sys.executable, "-c", script],
+        env     =env,
+        stdout  =subprocess.PIPE,
+        text    =True,
+        check   =True,
+    )
+    return proc.stdout
+
+
+@pytest.mark.parametrize("zoneinfo_path", (None, ""))
+def test_sytem_zoneinfo_dir(zoneinfo_path):
+    # Get zoneinfo's path.
+    path = run(
+        "import zoneinfo; print(':'.join(zoneinfo.TZPATH))",
+        zoneinfo_path
+    )
+    path = [ Path(p) for p in path.strip().split(":") if Path(p).is_absolute() ]
+
+    # Find the first entry that exists.
+    try:
+        zoneinfo_dir = next( p for p in path if p.is_dir() )
+    except StopIteration:
+        if tzdata is None:
+            zoneinfo_dir = ora._INTERNAL_ZONEINFO_DIR
+        else:
+            zoneinfo_dir = Path(tzdata.__file__).parent / "zoneinfo"
+    assert zoneinfo_dir.is_dir()
+
+    # Get Ora's zoneinfo dir.
+    ora_dir = run("import ora; print(ora.get_zoneinfo_dir())", zoneinfo_path)
+    ora_dir = Path(ora_dir.strip())
+    assert ora_dir == zoneinfo_dir
+
+

--- a/python/ora/test/test_time_zone_dir.py
+++ b/python/ora/test/test_time_zone_dir.py
@@ -9,6 +9,8 @@ try:
 except ImportError:
     tzdata = None
 
+import ora
+
 # Note: if PYTHONTZPATH is the empty string, `zoneinfo.TZPATH` contains a single
 # entry, `.`.  However, `zoneinfo` ignores relative dir paths in `TZPATH`.
 


### PR DESCRIPTION
Ora now chooses a zoneinfo directory similarly to the standard `zoneinfo` module.  By default, it uses a system zoneinfo directory, if available; 
else, the data installed with the `tzdata` module, if available; else the zoneinfo directory packaged with Ora itself.

Resolves #25 
